### PR TITLE
Add type hint for stopPropagation() parameter.

### DIFF
--- a/src/StoppableEventInterface.php
+++ b/src/StoppableEventInterface.php
@@ -24,7 +24,7 @@ interface StoppableEventInterface extends EventInterface
      *
      * @return self
      */
-    public function stopPropagation($stop = true) : self;
+    public function stopPropagation(bool $stop = true) : self;
 
     /**
      * Is propagation stopped?


### PR DESCRIPTION
I missed this before, but there's no reason not to have it there.