### PR TITLE
docs: Standardize the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Event Dispatcher
 
 This repository holds all interfaces related to [PSR-14 (Event Dispatcher)][psr-url].
 
-Note that this is not an Event Dispatcher of its own. It is merely interfaces that describe the components of an Event Dispatcher.
+Note that this is not an Event Dispatcher implementation of its own. It is merely interfaces that describe the components of an Event Dispatcher.
 
 You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-PSR Event Dispatcher
-====================
+Event Dispatcher
+==============
 
-This repository holds the interfaces related to [PSR-14](http://www.php-fig.org/psr/psr-14/).
+This repository holds all interfaces related to [PSR-14 (Event Dispatcher)][psr-link].
 
-Note that this is not an Event Dispatcher implementation of its own. It is merely interfaces that describe the components of an Event Dispatcher.  See the specification for more details.
+Note that this is not an Event Dispatcher implementation of its own. It is merely interfaces that describe the components of an Event Dispatcher.
+
+You can see the [specification][psr-link] for more details and find implementations of the specification by looking for packages providing the [psr/event-dispatcher-implementation][implementation-link] virtual package.
+
+[psr-link]: https://www.php-fig.org/psr/psr-14/
+[implementation-link]: https://packagist.org/providers/psr/event-dispatcher-implementation

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 Event Dispatcher
 ==============
 
-This repository holds all interfaces related to [PSR-14 (Event Dispatcher)][psr-link].
+This repository holds all interfaces related to [PSR-14 (Event Dispatcher)][psr-url].
 
-Note that this is not an Event Dispatcher implementation of its own. It is merely interfaces that describe the components of an Event Dispatcher.
+Note that this is not an Event Dispatcher of its own. It is merely interfaces that describe the components of an Event Dispatcher.
 
-You can see the [specification][psr-link] for more details and find implementations of the specification by looking for packages providing the [psr/event-dispatcher-implementation][implementation-link] virtual package.
+You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
 
-[psr-link]: https://www.php-fig.org/psr/psr-14/
-[implementation-link]: https://packagist.org/providers/psr/event-dispatcher-implementation
+[psr-url]: https://www.php-fig.org/psr/psr-14/
+[package-url]: https://packagist.org/packages/psr/event-dispatcher
+[implementation-url]: https://packagist.org/providers/psr/event-dispatcher-implementation


### PR DESCRIPTION
What:
Standardizes the README file providing a common language and an implementation link.

Why:
There are differences between PSR's READMEs in regarding language and the lacking of implementations references. So I've updated all READMEs using the https://github.com/php-fig/http-factory as a base.