### PR TITLE
Added EventInterface for correct overloading

### DIFF
--- a/src/EventDispatcherInterface.php
+++ b/src/EventDispatcherInterface.php
@@ -14,7 +14,7 @@ interface EventDispatcherInterface
      * @param EventInterface $event
      *   The object to process.
      *
-     * @return object
+     * @return EventInterface
      *   The Event that was passed, now modified by listeners.
      */
     public function dispatch(EventInterface $event);

--- a/src/EventDispatcherInterface.php
+++ b/src/EventDispatcherInterface.php
@@ -11,11 +11,11 @@ interface EventDispatcherInterface
     /**
      * Provide all relevant listeners with an event to process.
      *
-     * @param object $event
+     * @param EventInterface $event
      *   The object to process.
      *
      * @return object
      *   The Event that was passed, now modified by listeners.
      */
-    public function dispatch(object $event);
+    public function dispatch(EventInterface $event);
 }

--- a/src/EventInterface.php
+++ b/src/EventInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Psr\EventDispatcher;
+
+/**
+ * Defines a event.
+ */
+class EventInterface
+{
+
+}

--- a/src/ListenerProviderInterface.php
+++ b/src/ListenerProviderInterface.php
@@ -9,11 +9,11 @@ namespace Psr\EventDispatcher;
 interface ListenerProviderInterface
 {
     /**
-     * @param object $event
+     * @param EventInterface $event
      *   An event for which to return the relevant listeners.
      * @return iterable[callable]
      *   An iterable (array, iterator, or generator) of callables.  Each
      *   callable MUST be type-compatible with $event.
      */
-    public function getListenersForEvent(object $event) : iterable;
+    public function getListenersForEvent(EventInterface $event) : iterable;
 }


### PR DESCRIPTION
Current realization of EventDispatcherInterface not compatible with overloading:
```php
class Dispatcher implements EventDispatcherInterface
{
    public function dispatch(EventInterface $event) { ... }
    // Fatal error:  Declaration of Dispatcher::dispatch(EventInterface $event) must be compatible with EventDispatcherInterface::dispatch(object $event)
}
```