### PR TITLE
Return type hint compatible with code analyzers

### DIFF
--- a/src/ListenerProviderInterface.php
+++ b/src/ListenerProviderInterface.php
@@ -11,7 +11,7 @@ interface ListenerProviderInterface
     /**
      * @param object $event
      *   An event for which to return the relevant listeners.
-     * @return iterable[callable]
+     * @return iterable<callable>
      *   An iterable (array, iterator, or generator) of callables.  Each
      *   callable MUST be type-compatible with $event.
      */


### PR DESCRIPTION
Common code analyzers such as PhpStan and Psalm don't understand the notation 
`@return iterable[callable]`
But they work as expected with
`@return iterable<callable>`