### PR TITLE
Add return type hint to EventDispatcherInterface::dispatch()

### DIFF
--- a/src/EventDispatcherInterface.php
+++ b/src/EventDispatcherInterface.php
@@ -17,5 +17,5 @@ interface EventDispatcherInterface
      * @return object
      *   The Event that was passed, now modified by listeners.
      */
-    public function dispatch(object $event);
+    public function dispatch(object $event): object;
 }


### PR DESCRIPTION
Currently the method signature is inconsistent with the doc block.