### PR TITLE
Fix missing linebreak in ListenerProviderInterface's docblock

### DIFF
--- a/src/ListenerProviderInterface.php
+++ b/src/ListenerProviderInterface.php
@@ -11,6 +11,7 @@ interface ListenerProviderInterface
     /**
      * @param object $event
      *   An event for which to return the relevant listeners.
+     *
      * @return iterable<callable>
      *   An iterable (array, iterator, or generator) of callables.  Each
      *   callable MUST be type-compatible with $event.


### PR DESCRIPTION
For consistency. Spec updated accordingly in https://github.com/php-fig/fig-standards/pull/1302