### PR TITLE
Enhance type inference for the Dispatch Method by adding a @template Annotation

### DIFF
--- a/src/EventDispatcherInterface.php
+++ b/src/EventDispatcherInterface.php
@@ -12,10 +12,12 @@ interface EventDispatcherInterface
     /**
      * Provide all relevant listeners with an event to process.
      *
-     * @param object $event
+     * @template T of object
+     *
+     * @param T $event
      *   The object to process.
      *
-     * @return object
+     * @return T
      *   The Event that was passed, now modified by listeners.
      */
     public function dispatch(object $event);


### PR DESCRIPTION
`@template` was added to indicate that the same type is returned that was passed as an object to the dispatch method. This change is useful because static code analysers would otherwise interpret the return of the dispatch method as a generic object. See [before](https://phpstan.org/r/16b67279-1560-451c-b00d-a9c224864ee2) and [after](https://phpstan.org/r/06555e83-cdcc-45ff-a25f-3024b4b2b1b6).